### PR TITLE
Fixed blockly blockage blocks menu + Porting Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ npm run dev
 npm start
 ```
 
-The server will be available at `http://localhost:3000`
+The server will be available at `http://localhost:3000` by default. If port 3000 is already in use, the server will automatically try the next available port (up to 10 consecutive ports).
 
 ### Available Interfaces
 
-- **Main Application**: `http://localhost:3000/` - Block-based programming interface
-- **Hand Tracking AR**: `http://localhost:3000/ar-demo` - MediaPipe hand gesture controls
-- **Hybrid AR Demo**: `http://localhost:3000/hybrid-ar` - Combined markers + hand tracking
+- **Main Application**: `http://localhost:[PORT]/` - Block-based programming interface
+- **Hand Tracking AR**: `http://localhost:[PORT]/ar-demo` - MediaPipe hand gesture controls
+- **Hybrid AR Demo**: `http://localhost:[PORT]/hybrid-ar` - Combined markers + hand tracking
+
+Where `[PORT]` is the port number shown in the server startup message (3000 by default, or the next available port if 3000 is in use).
 
 ## Architecture Overview
 
@@ -88,8 +90,10 @@ src/ar/
 ### Base URL
 
 ```
-http://localhost:3000
+http://localhost:[PORT]
 ```
+
+Where `[PORT]` is the port number shown in the server startup message (3000 by default, or the next available port if 3000 is in use).
 
 ### Endpoints
 

--- a/server.js
+++ b/server.js
@@ -180,11 +180,34 @@ app.use((error, req, res, next) => {
 
 // Start server only if this is the main module (not when imported for testing)
 if (require.main === module) {
-  app.listen(PORT, () => {
-    console.log(`ApparentlyAR server running on http://localhost:${PORT}`);
-    console.log(`Data visualization backend ready`);
-    console.log(`AR endpoints available at /api/ar-visualization`);
-  });
+  // Function to start server on a specific port
+  const startServer = (port) => {
+    const server = app.listen(port, () => {
+      console.log(`ApparentlyAR server running on http://localhost:${port}`);
+      console.log(`Data visualization backend ready`);
+      console.log(`AR endpoints available at /api/ar-visualization`);
+    });
+
+    server.on('error', (err) => {
+      if (err.code === 'EADDRINUSE') {
+        console.log(`Port ${port} is already in use.`);
+        const nextPort = port + 1;
+        // Try up to 10 consecutive ports
+        if (nextPort < port + 10) {
+          console.log(`Trying port ${nextPort}...`);
+          startServer(nextPort);
+        } else {
+          console.error('Unable to find an available port after 10 attempts.');
+          process.exit(1);
+        }
+      } else {
+        console.error('Server error:', err);
+      }
+    });
+  };
+
+  // Start server on the configured port
+  startServer(PORT);
 }
 
 module.exports = app;


### PR DESCRIPTION
1. Fixed the issue with the scrollbar of blockly blocking the block section.
2. Fixed the issue with the porting (e.g if someone used PORT 3000, it redirects to another port)