### PR TITLE
Autofill helper fr

### DIFF
--- a/src/blocks/csv_import.js
+++ b/src/blocks/csv_import.js
@@ -73,6 +73,13 @@ class FieldFileButton extends Blockly.Field {
               Blockly.CsvImportData.data = results.data;
               Blockly.CsvImportData.filename = file.name;
               this._dialogOpen = false;
+              
+              // Trigger autofill for all existing blocks when CSV data is loaded
+              if (window.BlocklyAutofill && window.BlocklyAutofill.updateAllBlocksWithAutofill) {
+                setTimeout(() => {
+                  window.BlocklyAutofill.updateAllBlocksWithAutofill();
+                }, 100); // Small delay to ensure blocks are rendered
+              }
             }
           });
         };

--- a/src/blocks/csv_import.js
+++ b/src/blocks/csv_import.js
@@ -80,6 +80,13 @@ class FieldFileButton extends Blockly.Field {
                   window.BlocklyAutofill.updateAllBlocksWithAutofill();
                 }, 100); // Small delay to ensure blocks are rendered
               }
+              
+              // Also trigger autofill for statistics blocks
+              if (window.BlocklyStatisticsAutofill && window.BlocklyStatisticsAutofill.updateAllStatisticsBlocksWithAutofill) {
+                setTimeout(() => {
+                  window.BlocklyStatisticsAutofill.updateAllStatisticsBlocksWithAutofill();
+                }, 150); // Slightly longer delay for statistics blocks
+              }
             }
           });
         };

--- a/src/blocks/data_ops.js
+++ b/src/blocks/data_ops.js
@@ -28,6 +28,28 @@
  */
 // === Data Processing Block (Backend) ===
 (function(){
+  // Helper function to get available columns from CSV data
+  function getAvailableColumns() {
+    const csvData = window.Blockly && window.Blockly.CsvImportData && window.Blockly.CsvImportData.data;
+    if (csvData && Array.isArray(csvData) && csvData.length > 0) {
+      return Object.keys(csvData[0]);
+    }
+    return [];
+  }
+
+  // Helper function to update field options with available columns
+  function updateFieldWithColumns(field, isMultiSelect = false) {
+    if (field && field.setOptions) {
+      const columns = getAvailableColumns();
+      if (columns.length > 0) {
+        const options = isMultiSelect 
+          ? [['All columns', 'all'], ...columns.map(col => [col, col])]
+          : columns.map(col => [col, col]);
+        field.setOptions(options);
+      }
+    }
+  }
+
   // Wait for Blockly to be available
   function waitForBlockly() {
     if (typeof Blockly !== 'undefined' && Blockly.JavaScript) {
@@ -70,7 +92,7 @@
       ],
       "output": "Dataset",
       "colour": 20,
-      "tooltip": "Filter data based on a condition",
+      "tooltip": "Filter data based on a condition. Use updateFieldWithColumns(block.getField('COLUMN')) to populate with available columns.",
       "helpUrl": ""
     },
     {
@@ -322,4 +344,10 @@
   
   // Start waiting for Blockly
   waitForBlockly();
+  
+  // Export helper functions for autofill functionality
+  window.BlocklyAutofill = {
+    getAvailableColumns,
+    updateFieldWithColumns
+  };
 })();


### PR DESCRIPTION
Added helper method for autofilling based on column names. 
Helper was assigned to the blocks to trigger when created through listeners. 
I defo could have missed some blocks. 
Removed how autofill only worked for statistics general helper in dataops.js.